### PR TITLE
Simplify repro: don't need a separate library

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,20 +1,8 @@
-cc_library(
-    name = "grpc_slice_alt",
-    srcs = [
-        ":slice2.cc",
-    ],
-    hdrs = [
-        ":include/slice2.h",
-    ],
-    includes = [
-            "include", 
-    ]
-)
-
 cc_binary(
     name = "main",
-    srcs = ["main.cc"],
-    deps = [
-        "//:grpc_slice_alt"
+    srcs = ["main.cc", "slice2.cc"],
+    
+    includes = [
+        "include", 
     ]
 )

--- a/build.bat
+++ b/build.bat
@@ -8,5 +8,4 @@ cl.exe /Bv
 cl.exe /nologo /DCOMPILER_MSVC /DNOMINMAX /D_WIN32_WINNT=0x0601 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_SECURE_NO_WARNINGS /bigobj /Zm500 /EHsc /wd4351 /wd4291 /wd4250 /wd4996 /I. /Iinclude /MD /O2 /Oy- /DNDEBUG /wd4117 /Gy /Gw /c slice2.cc
 cl.exe /nologo /DCOMPILER_MSVC /DNOMINMAX /D_WIN32_WINNT=0x0601 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_SECURE_NO_WARNINGS /bigobj /Zm500 /EHsc /wd4351 /wd4291 /wd4250 /wd4996 /I. /Iinclude /MD /O2 /Oy- /DNDEBUG /wd4117 /Gy /Gw /c main.cc
 
-lib.exe /nologo /MACHINE:X64 slice2.obj /ignore:4221
-link.exe /nologo main.obj slice2.lib /SUBSYSTEM:CONSOLE /MACHINE:X64 /DEFAULTLIB:msvcrt.lib /OPT:ICF /OPT:REF
+link.exe /nologo main.obj slice2.obj /SUBSYSTEM:CONSOLE /MACHINE:X64 /DEFAULTLIB:msvcrt.lib /OPT:ICF /OPT:REF

--- a/main.cc
+++ b/main.cc
@@ -28,14 +28,14 @@ int main(int argc, char** argv) {
   // - the src1.refcount will always be nullptr (see grpc_empty_slice_alt function)
   //   but compiler doesn't seem to be able to guess that because grpc_empty_slice_alt definition
   //   is in a different library (if we move its code locally, compiler behaves correctly)
-  // 
+  //
   if ((src1.refcount ? nullptr : src1.bytes) == (src2.refcount ? nullptr : src2.bytes))
   {
       // necessary conditions for the assertion failure to happen
       // - build in optimized mode (in debug mode things work correctly)
       // - the grpc_slice_alt struct needs to contain a fixed-size array
-      // - grpc_slice_alt implementation has to be in a different library
-      
+      // - grpc_slice_alt implementation has to be in a different compilation unit
+
       std::cerr << "Assertion failed\n";
       std::cerr << "This should never happen and means that the compiler has wrongly assumed\n";
       std::cerr << "that src1 and src2 addresses are not observable and has reduced src1 and src2 into\n";


### PR DESCRIPTION
At least with MSVC 2019 14.23.28105 and 14.24.28207, I'm hitting the bug just with a separate compilation unit.